### PR TITLE
Use settings module from DJANGO_SETTINGS_MODULE if data is not passed to configure_toml_settings()

### DIFF
--- a/src/dj_toml_settings/config.py
+++ b/src/dj_toml_settings/config.py
@@ -1,6 +1,10 @@
+import importlib
 import logging
+import os
 from pathlib import Path
 from typing import Any
+
+from typeguard import typechecked
 
 from dj_toml_settings.toml_parser import Parser
 
@@ -12,10 +16,32 @@ TOML_SETTINGS_FILES = [
 ]
 
 
+@typechecked
 def configure_toml_settings(
-    data: dict, base_dir: Path = Path("."), toml_settings_files: list[str] | None = None
+    data: dict | None = None, base_dir: Path = Path("."), toml_settings_files: list[str] | None = None
 ) -> None:
-    data.update(get_toml_settings(data=data, base_dir=base_dir, toml_settings_files=toml_settings_files))
+    """Configure Django settings from TOML files.
+
+    Args:
+        base_dir: Base directory to look for TOML files
+        data: Dictionary to update with settings from TOML files
+
+    Returns:
+        The updated dictionary with settings from TOML files
+    """
+
+    toml_settings = get_toml_settings(data=data, base_dir=base_dir, toml_settings_files=toml_settings_files)
+
+    if data is not None:
+        data.update(toml_settings)
+    else:
+        if django_settings_module := os.getenv("DJANGO_SETTINGS_MODULE"):
+            module = importlib.import_module(django_settings_module)
+
+            for k, v in toml_settings.items():
+                setattr(module, k, v)
+
+        raise RuntimeError("No DJANGO_SETTINGS_MODULE environment variable configured")
 
 
 def get_toml_settings(

--- a/src/dj_toml_settings/config.py
+++ b/src/dj_toml_settings/config.py
@@ -34,13 +34,12 @@ def configure_toml_settings(
 
     if data is not None:
         data.update(toml_settings)
+    elif django_settings_module := os.getenv("DJANGO_SETTINGS_MODULE"):
+        module = importlib.import_module(django_settings_module)
+
+        for k, v in toml_settings.items():
+            setattr(module, k, v)
     else:
-        if django_settings_module := os.getenv("DJANGO_SETTINGS_MODULE"):
-            module = importlib.import_module(django_settings_module)
-
-            for k, v in toml_settings.items():
-                setattr(module, k, v)
-
         raise RuntimeError("No DJANGO_SETTINGS_MODULE environment variable configured")
 
 

--- a/tests/test_config/test_configure_toml_settings.py
+++ b/tests/test_config/test_configure_toml_settings.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import ModuleType
 
 from dj_toml_settings.config import configure_toml_settings
 
@@ -169,3 +170,23 @@ def test_default_settings():
     configure_toml_settings(base_dir=test_dir, data=actual)
 
     assert expected == actual
+
+
+def test_configure_toml_settings_without_data_parameter(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "dj_toml_settings.config.get_toml_settings",
+        lambda *_: {
+            "DEBUG": True,
+        },
+    )
+
+    settings_module = ModuleType("test.settings")
+
+    monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "test.settings")
+    monkeypatch.setattr(
+        "importlib.import_module",
+        lambda *_: settings_module,
+    )
+    configure_toml_settings(base_dir=tmp_path)
+
+    assert settings_module.DEBUG is True

--- a/tests/test_config/test_configure_toml_settings.py
+++ b/tests/test_config/test_configure_toml_settings.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 from dj_toml_settings.config import configure_toml_settings
 
 
@@ -175,7 +177,7 @@ def test_default_settings():
 def test_configure_toml_settings_without_data_parameter(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "dj_toml_settings.config.get_toml_settings",
-        lambda *_: {
+        lambda **_: {
             "DEBUG": True,
         },
     )
@@ -190,3 +192,10 @@ def test_configure_toml_settings_without_data_parameter(monkeypatch, tmp_path):
     configure_toml_settings(base_dir=tmp_path)
 
     assert settings_module.DEBUG is True
+
+
+def test_configure_toml_settings_without_dsm(monkeypatch, tmp_path):
+    monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
+
+    with pytest.raises(RuntimeError, match="No DJANGO_SETTINGS_MODULE environment variable configured"):
+        configure_toml_settings(base_dir=tmp_path)


### PR DESCRIPTION
If the data parameter is not passed to configure_toml_settings, automatically detect the settings module based on the DJANGO_SETTINGS_MODULE environment variable, and set the settings attributes in the module.

Fixes #5